### PR TITLE
Add Contributor-Recipe relationship

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -4,4 +4,5 @@ class Contributor < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :profile_name, presence: true, uniqueness: true
+  has_many :recipes, :dependent => :destroy
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,4 @@
 class Recipe < ApplicationRecord
   validates :title, presence: true, uniqueness: true
+  belongs_to :contributor, counter_cache: true
 end

--- a/db/migrate/20220403100136_add_reference_to_recipes.rb
+++ b/db/migrate/20220403100136_add_reference_to_recipes.rb
@@ -1,0 +1,6 @@
+class AddReferenceToRecipes < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :recipes, :contributor, null: false, foreign_key: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_30_145815) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_03_100136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_145815) do
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "contributor_id", null: false
+    t.index ["contributor_id"], name: "index_recipes_on_contributor_id"
   end
 
+  add_foreign_key "recipes", "contributors"
 end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :recipe do
     sequence(:title) { |number| "Recipe #{number}" }
+    contributor
   end
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -17,3 +17,29 @@ RSpec.describe Recipe, type: :model do
   end
 end
 
+RSpec.describe Recipe, type: :model do
+  context "with no contributor" do
+    it "should have an error on contributor" do
+      recipe = Recipe.new
+      recipe.valid?
+     # puts recipe.errors.inspect
+      expect(recipe.errors.of_kind?(:contributor, :blank)).to eq(true)
+    end
+  end
+end
+
+RSpec.describe Recipe, type: :model do
+  context "with title that's already taken" do
+
+    let(:other_recipe) { FactoryBot.create(:recipe) }
+
+    it "should have a uniqueness error on title" do
+
+      recipe = Recipe.new(title: other_recipe.title)
+      recipe.valid?
+      puts recipe.errors.inspect
+      expect(recipe.errors.of_kind?(:title, :taken)).to eq(true)
+    end
+  end
+end
+


### PR DESCRIPTION
- A Contributor has_many recipes and a Recipe belongs_to a contributor.
- Update Factory for Recipe so that it must include a contributor id and add tests.
- Check counter cache is working (in terminal).